### PR TITLE
Fix home data loading and auto theme

### DIFF
--- a/app/theme_manager.py
+++ b/app/theme_manager.py
@@ -219,6 +219,13 @@ class ThemeManager:
         finally:
             self._loading_in_progress = False
 
+    # ------------------------------------------------------------------
+    # Compatibility wrapper
+    # ------------------------------------------------------------------
+    def load_theme(self, theme_name, variant="light"):
+        """Alias for :func:`load` maintained for backward compatibility."""
+        return self.load(theme_name, variant)
+
     def _preload_common_resources(self):
         """Предзагрузка часто используемых ресурсов"""
         try:

--- a/pages/home.py
+++ b/pages/home.py
@@ -193,6 +193,8 @@ class HomeScreen(BaseScreen):
             app = App.get_running_app()
             if not hasattr(app, 'weather_service') or not app.weather_service:
                 logger.warning("Weather service not available")
+                # Попробуем еще раз через секунду
+                Clock.schedule_once(lambda dt: self.update_weather(), 1)
                 return
 
             weather_service = app.weather_service
@@ -232,7 +234,7 @@ class HomeScreen(BaseScreen):
                 self.weather_trend_arrow = "→"
             
             logger.debug("Weather data updated")
-            
+
         except Exception as e:
             logger.error(f"Error updating weather: {e}")
 
@@ -253,9 +255,10 @@ class HomeScreen(BaseScreen):
             # ИСПРАВЛЕНО: Используем alarm_service вместо user_config
             if not hasattr(app, 'alarm_service') or not app.alarm_service:
                 logger.warning("Alarm service not available")
-                # Устанавливаем дефолтные значения
+                # Устанавливаем дефолтные значения и пробуем позже
                 self.current_alarm_time = "--:--"
                 self.alarm_status_text = "OFF"
+                Clock.schedule_once(lambda dt: self.update_alarm_status(), 1)
                 return
             
             # Получаем данные из alarm_service


### PR DESCRIPTION
## Summary
- ensure HomeScreen retries weather and alarm updates until services start
- expose `load_theme` alias in ThemeManager for AutoThemeService

## Testing
- `pytest -q`
- `python -m py_compile main.py app/theme_manager.py pages/home.py services/auto_theme_service.py services/alarm_service.py services/weather_service.py widgets/root_widget.py widgets/base_screen.py`

------
https://chatgpt.com/codex/tasks/task_e_6850b62d45b4832ea8fef4f5fc877715